### PR TITLE
Fix responsive width for StPageFlip book

### DIFF
--- a/livre_digital_cnra_stpageflip.html
+++ b/livre_digital_cnra_stpageflip.html
@@ -610,6 +610,10 @@
                 padding: 0.3rem 0.6rem;
                 min-width: 80px;
             }
+            .flip-book {
+                width: 100% !important;
+                height: auto;
+            }
         }
 
         @media (max-width: 480px) {
@@ -1240,7 +1244,7 @@
             
             pageFlip = new St.PageFlip(document.getElementById('book'), {
                 width: 550, height: 733,
-                size: 'stretch', minWidth: 315, maxWidth: 1000,
+                size: 'stretch', minWidth: 280, maxWidth: 900,
                 minHeight: 420, maxHeight: 1350,
                 maxShadowOpacity: 0.7, showCover: true,
                 mobileScrollSupport: false, flippingTime: 1000,


### PR DESCRIPTION
## Summary
- ensure the book expands on small screens with new CSS rule
- tune StPageFlip minWidth and maxWidth for mobile devices

## Testing
- `npm test` *(fails: ENOENT could not read package.json)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_684014ecf9ac8329918571052444e8a8